### PR TITLE
Add sops to base image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,9 +11,10 @@ RUN addgroup -g 1000 ${USER} && adduser -D -G ${USER} -u 1000 ${USER}
 
 # System dependencies
 RUN apk add --no-cache \
-linux-headers coreutils ca-certificates libressl libressl-dev musl-dev \
-gcc g++ python3 python3-dev \
-git curl
+  linux-headers coreutils ca-certificates libressl libressl-dev musl-dev g++ python3 python3-dev git curl && \
+  wget https://github.com/mozilla/sops/releases/download/3.0.5/sops-3.0.5.linux -O sops && \
+  sha1sum sops | grep 7e3ec5f8f725976c8190544f8fd71400179ba666 && \
+  chmod +x sops && mv sops /usr/local/bin
 
 # RDS SSL certificates
 COPY rds-combined-ca-bundle.pem /tmp

--- a/Dockerfile.analytics
+++ b/Dockerfile.analytics
@@ -14,7 +14,8 @@ RUN echo "http://dl-8.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
 RUN apk --no-cache --update-cache add gfortran build-base wget freetype-dev libpng-dev openblas-dev
 RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 
-RUN pip3 install matplotlib==2.0.2 \
+RUN pip3 install numpy==1.14.3 # pinning this at 1.14.3 as 1.14.4 does not compile \
+    && pip3 install matplotlib==2.0.2 \
     pandas==0.22.0 \
     psycopg2==2.7.2 \
     scipy==1.0.1 \


### PR DESCRIPTION
Also had to pin numpy to 1.14.3 as 1.14.4 is not compiling. Moving the analytics image to debian seems worthwhile if it'll avoid these kinds of issues.