### PR TITLE
Fix analytics base image

### DIFF
--- a/Dockerfile.analytics
+++ b/Dockerfile.analytics
@@ -11,7 +11,7 @@ RUN apk add --no-cache libffi-dev \
 
 # Matplotlib dependencies from https://gist.github.com/orenitamar/f29fb15db3b0d13178c1c4dd611adce2
 RUN echo "http://dl-8.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk --no-cache --update-cache add gfortran build-base wget freetype-dev libpng-dev openblas-dev
+RUN apk --no-cache --update-cache add gfortran build-base wget freetype-dev libpng-dev openblas-dev lapack-dev
 RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 
 RUN pip3 install numpy==1.17.0 \


### PR DESCRIPTION
Will retag analytics alpine 3.10 which will add in the latest certs to fix datalake-etl and guzzler.